### PR TITLE
Unref http request after http message decodes, and on socket on connection error.

### DIFF
--- a/examples/http-client-loop.c
+++ b/examples/http-client-loop.c
@@ -4,10 +4,9 @@
 
 #include "ut.h"
 
+static void response_cb(UtObject *object, UtObject *response);
+
 UtObjectRef client;
-
-static void response_cb(UtObject *object, UtObject *request, UtObject *response);
-
 int counter;
 
 static size_t body_cb(UtObject *url_obj, UtObject *data, bool complete) {
@@ -29,7 +28,7 @@ static size_t body_cb(UtObject *url_obj, UtObject *data, bool complete) {
   return ut_list_get_length(data);
 }
 
-static void response_cb(UtObject *url_obj, UtObject *request,  UtObject *response) {
+static void response_cb(UtObject *url_obj, UtObject *response) {
   // You get a system error for "Connection refused"
   if (ut_object_implements_error(response)) {
     fprintf(stderr, "%s\n", ut_error_get_description(response));
@@ -45,7 +44,8 @@ static void response_cb(UtObject *url_obj, UtObject *request,  UtObject *respons
     return;
   }
 
-  ut_input_stream_read_all(ut_http_response_get_body(response), url_obj,
+  ut_input_stream_read_all(ut_http_response_get_body(response),
+                           url_obj,
                            body_cb);
 }
 
@@ -55,12 +55,12 @@ int main(int argc, char **argv) {
     return 1;
   }
   const char *url = argv[1];
-  counter = 0;
 
-  UtObject *url_str = ut_string_new(url);
+  counter = 0;
   client = ut_http_client_new();
 
-  ut_http_client_send_request(client, "GET", url, NULL,url_str,
+  UtObject *url_obj = ut_string_new(url);
+  ut_http_client_send_request(client, "GET", url, NULL,url_obj,
                               response_cb);
 
   UtObjectRef return_code = ut_event_loop_run();

--- a/examples/http-client-loop.c
+++ b/examples/http-client-loop.c
@@ -1,0 +1,68 @@
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+
+#include "ut.h"
+
+UtObjectRef client;
+
+static void response_cb(UtObject *object, UtObject *request, UtObject *response);
+
+int counter;
+
+static size_t body_cb(UtObject *url_obj, UtObject *data, bool complete) {
+
+  UtObjectRef data_string = ut_string_new_from_utf8(data);
+  printf("%d %s", counter, ut_string_get_text(data_string));
+
+  counter++;
+
+  if (complete) {
+    ut_http_client_send_request(client,
+      "GET",
+      ut_string_get_text(url_obj),
+      NULL,
+      url_obj,
+      response_cb);
+  }
+
+  return ut_list_get_length(data);
+}
+
+static void response_cb(UtObject *url_obj, UtObject *request,  UtObject *response) {
+  // You get a system error for "Connection refused"
+  if (ut_object_implements_error(response)) {
+    fprintf(stderr, "%s\n", ut_error_get_description(response));
+    ut_event_loop_return(ut_int32_new(1));
+    return;
+  }
+
+  int status = ut_http_response_get_status_code(response);
+  if (status!= 200) {
+    fprintf(stderr, "%s\n", ut_http_response_get_reason_phrase(response));
+    UtObjectRef return_code = ut_int32_new(2);
+    ut_event_loop_return(return_code);
+    return;
+  }
+
+  ut_input_stream_read_all(ut_http_response_get_body(response), url_obj,
+                           body_cb);
+}
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    printf("Usage: http [url]\n");
+    return 1;
+  }
+  const char *url = argv[1];
+  counter = 0;
+
+  UtObject *url_str = ut_string_new(url);
+  client = ut_http_client_new();
+
+  ut_http_client_send_request(client, "GET", url, NULL,url_str,
+                              response_cb);
+
+  UtObjectRef return_code = ut_event_loop_run();
+  return ut_int32_get_value(return_code);
+}

--- a/examples/http.c
+++ b/examples/http.c
@@ -12,7 +12,7 @@ static size_t body_cb(UtObject *object, UtObject *data, bool complete) {
   return ut_list_get_length(data);
 }
 
-static void response_cb(UtObject *object, UtObject *request,  UtObject *response) {
+static void response_cb(UtObject *object, UtObject *response) {
   // You get a system error for "Connection refused"
   if (ut_object_implements_error(response)) {
     fprintf(stderr, "%s\n", ut_error_get_description(response));

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -3,6 +3,12 @@ executable('http',
            include_directories: ut_include,
            link_with: ut_lib)
 
+executable('http-client-loop',
+           'http-client-loop.c',
+           include_directories: ut_include,
+           link_with: ut_lib)
+
+
 executable('http-server',
            'http-server.c',
            include_directories: ut_include,

--- a/src/http/ut-http-client.c
+++ b/src/http/ut-http-client.c
@@ -130,7 +130,7 @@ static size_t read_cb(UtObject *object, UtObject *data, bool complete) {
         ut_http_message_decoder_get_body(request->message_decoder));
 
     if (request->callback_object != NULL && request->callback != NULL) {
-      request->callback(request->callback_object, object, response);
+      request->callback(request->callback_object, response);
     }
   }
 
@@ -144,7 +144,7 @@ static void connect_cb(UtObject *object, UtObject *error) {
 
   if (error != NULL) {
     if (request->callback_object != NULL && request->callback != NULL) {
-      request->callback(request->callback_object, object, error);
+      request->callback(request->callback_object, error);
     }
     ut_request_unref(object);
     return;

--- a/src/http/ut-http-client.c
+++ b/src/http/ut-http-client.c
@@ -8,6 +8,7 @@
 
 typedef struct {
   UtObject object;
+  UtObject *client;
   UtObject *tcp_socket;
   char *host;
   uint16_t port;
@@ -53,11 +54,13 @@ static UtObjectInterface request_object_interface = {.type_name = "HttpRequest",
 
 UtObject *http_request_new(const char *host, uint16_t port, const char *method,
                            const char *path, UtObject *body,
+                           UtObject *client_object,
                            UtObject *callback_object,
                            UtHttpResponseCallback callback) {
   UtObject *object =
       ut_object_new(sizeof(HttpRequest), &request_object_interface);
   HttpRequest *self = (HttpRequest *)object;
+  self->client = client_object;
   self->host = ut_cstring_new(host);
   self->port = port;
   self->method = ut_cstring_new(method);
@@ -86,6 +89,30 @@ static void ut_http_client_cleanup(UtObject *object) {
   ut_object_unref(self->requests);
 }
 
+static void ut_request_unref(UtObject *req_object) {
+  HttpRequest *request = (HttpRequest *)req_object;
+  UtHttpClient* client = (UtHttpClient*)request->client;
+
+  for (size_t i = 0; i < ut_list_get_length(client->requests); i++) {
+    UtObject* req = ut_list_get_element(client->requests, i);
+    if (req == req_object) {
+      ut_list_remove(client->requests, i, 1);
+      break;
+    }
+  }
+
+  ut_object_unref(req_object);
+}
+
+static void ut_check_requests_for_unref(UtObject *object) {
+  HttpRequest *request = (HttpRequest *)object;
+
+  if (!ut_http_message_decoder_get_done(request->message_decoder))
+    return;
+
+  ut_request_unref(object);
+}
+
 static size_t read_cb(UtObject *object, UtObject *data, bool complete) {
   HttpRequest *request = (HttpRequest *)object;
 
@@ -95,15 +122,19 @@ static size_t read_cb(UtObject *object, UtObject *data, bool complete) {
       request->message_decoder_input_stream, data, complete);
   if (!headers_done &&
       ut_http_message_decoder_get_headers_done(request->message_decoder)) {
+
     UtObjectRef response = ut_http_response_new(
         ut_http_message_decoder_get_status_code(request->message_decoder),
         ut_http_message_decoder_get_reason_phrase(request->message_decoder),
         ut_http_message_decoder_get_headers(request->message_decoder),
         ut_http_message_decoder_get_body(request->message_decoder));
+
     if (request->callback_object != NULL && request->callback != NULL) {
-      request->callback(request->callback_object, response);
+      request->callback(request->callback_object, object, response);
     }
   }
+
+  ut_check_requests_for_unref(object);
 
   return n_used;
 }
@@ -113,13 +144,16 @@ static void connect_cb(UtObject *object, UtObject *error) {
 
   if (error != NULL) {
     if (request->callback_object != NULL && request->callback != NULL) {
-      request->callback(request->callback_object, error);
+      request->callback(request->callback_object, object, error);
     }
+    ut_request_unref(object);
     return;
   }
 
   UtObjectRef headers = ut_list_new();
   ut_list_append_take(headers, ut_http_header_new("Host", request->host));
+  // we only do one connection per / requests currently.
+  ut_list_append_take(headers, ut_http_header_new("Connection", "close"));
   request->message_encoder = ut_http_message_encoder_new_request(
       request->tcp_socket, request->method, request->path, headers,
       request->body);
@@ -130,7 +164,6 @@ static void connect_cb(UtObject *object, UtObject *error) {
 
 static void lookup_cb(UtObject *object, UtObject *addresses) {
   HttpRequest *request = (HttpRequest *)object;
-
   UtObjectRef address = ut_list_get_first(addresses);
   request->tcp_socket = ut_tcp_socket_new(address, request->port);
   ut_tcp_socket_connect(request->tcp_socket, object, connect_cb);
@@ -150,7 +183,6 @@ void ut_http_client_send_request(UtObject *object, const char *method,
                                  UtHttpResponseCallback callback) {
   assert(ut_object_is_http_client(object));
   UtHttpClient *self = (UtHttpClient *)object;
-
   UtObjectRef uri_object = ut_uri_new_from_string(uri);
   assert(!ut_object_implements_error(uri_object));
   assert(ut_cstring_equal(ut_uri_get_scheme(uri_object), "http"));
@@ -166,7 +198,8 @@ void ut_http_client_send_request(UtObject *object, const char *method,
   }
 
   UtObjectRef request = http_request_new(host, port, method, path, body,
-                                         callback_object, callback);
+                               object, callback_object, callback);
+
   ut_list_append(self->requests, request);
   ut_ip_address_resolver_lookup(self->ip_address_resolver, host, request,
                                 lookup_cb);

--- a/src/http/ut-http-client.h
+++ b/src/http/ut-http-client.h
@@ -5,7 +5,7 @@
 #pragma once
 
 /// Method to handle a received HTTP [response].
-typedef void (*UtHttpResponseCallback)(UtObject *object, UtObject *request, UtObject *response);
+typedef void (*UtHttpResponseCallback)(UtObject *object, UtObject *response);
 
 /// Creates a new HTTP client.
 ///

--- a/src/http/ut-http-client.h
+++ b/src/http/ut-http-client.h
@@ -5,7 +5,7 @@
 #pragma once
 
 /// Method to handle a received HTTP [response].
-typedef void (*UtHttpResponseCallback)(UtObject *object, UtObject *response);
+typedef void (*UtHttpResponseCallback)(UtObject *object, UtObject *request, UtObject *response);
 
 /// Creates a new HTTP client.
 ///

--- a/src/ut-tcp-socket.c
+++ b/src/ut-tcp-socket.c
@@ -138,7 +138,11 @@ static void ut_tcp_socket_read(UtObject *object, UtObject *callback_object,
 
 static void ut_tcp_socket_close(UtObject *object) {
   UtTcpSocket *self = (UtTcpSocket *)object;
-  ut_event_loop_cancel_watch(self->read_watch);
+  if (self->read_watch != NULL)
+    ut_event_loop_cancel_watch(self->read_watch);
+  else
+    ut_file_descriptor_close(self->fd);
+
 }
 
 static UtInputStreamInterface input_stream_interface = {


### PR DESCRIPTION
I unref http request in `read_cb` if the message_decoder has an error or is DECODER_STATE_DONE.
This means one socket / per-request, and each request always supplies "Connection: close" header, so its valid http 1.1. I also added http 1.0, so it works with python webserver too.

Also the new example `http-client-loop.c` calls the webserver its pointed in a loop, by calling ut_http_client_send_request in the callbacks.

Not 100% if everything is in the right spots.

